### PR TITLE
WIP: Allow parsing more general OBO files

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -123,6 +123,11 @@ function tagvalue(line::ASCIIString)
     # TODO: what an ad hoc parser!
     i = searchindex(line, ": ")
     if i == 0
+        # empty tag value
+        if endswith(line, ":")
+            return line, "", true
+        end
+
         # empty strings are dummy
         return "", "", false
     end


### PR DESCRIPTION
I'm trying to parse [Brenda Tissue Ontology](http://www.brenda-enzymes.info/ontology/tissue/tree/update/update_files/BrendaTissueOBO) using GeneOntology.jl and running into problems. 

First one was that BTO has an empty tag that was treated as error by GO.jl (this is fixed in this PR). 
Next one is the assumption made by this package that Terms are always in the format of GO:xxxx which is not true for BTO. 

So the general question is if this package should support more general OBO ontology parsing, or if you wish to keep it for Gene Ontology only, maybe we can factor out generic code in some other package?
